### PR TITLE
♻️ Add aria-label to avoid breaking axe-core linter

### DIFF
--- a/packages/markdown/src/LegalNotice.md
+++ b/packages/markdown/src/LegalNotice.md
@@ -16,7 +16,7 @@ est édité par l’ADEME, ayant son siège social au :
 <address class="fr-mb-2w">
     20, avenue du Grésillé — BP 90406<br/>
     49004 Angers Cedex 01<br/>
-    Tél : <a target="_blank" href="tel:+33241204120">02 41 20 41 20</a>
+    Tél : <a target="_blank" aria-label="Numéro de téléphone" href="tel:+33241204120">02 41 20 41 20</a>
 </address>
 
 inscrit au registre du commerce d'Angers sous le n° 385 290 309, représentée par Sylvain Waserman, agissant en qualité

--- a/packages/markdown/src/LegalNotice_withBeta.md
+++ b/packages/markdown/src/LegalNotice_withBeta.md
@@ -16,7 +16,7 @@ est édité par l’ADEME, ayant son siège social au :
 <address class="fr-mb-2w">
     20, avenue du Grésillé — BP 90406<br/>
     49004 Angers Cedex 01<br/>
-    Tél : <a target="_blank" href="tel:+33241204120">02 41 20 41 20</a>
+    Tél : <a target="_blank" aria-label="Numéro de téléphone" href="tel:+33241204120">02 41 20 41 20</a>
 </address>
 
 inscrit au registre du commerce d'Angers sous le n° 385 290 309, représentée par Sylvain Waserman, agissant en qualité


### PR DESCRIPTION
Ce lien sans texte fait péter mon `cypress-axe` ; proposition d'amélioration :)

<img width="551" alt="Capture d’écran 2025-02-24 à 18 12 48" src="https://github.com/user-attachments/assets/a4367cd4-ecba-4cd5-a483-d81071c1ec14" />
